### PR TITLE
Contribution guideline link

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,1 @@
+Please view our [contribution guidelines](https://github.com/dwyl/contributing)


### PR DESCRIPTION
- adds CONTRIBUTING file in .github as link to contribution repo for future examples 
#8
